### PR TITLE
Enh/rng state

### DIFF
--- a/es/exponential_natural_es.py
+++ b/es/exponential_natural_es.py
@@ -16,7 +16,8 @@ def is_positive_definite(B):
 def optimize(func, mu, cov,
              learning_rate_mu=None, learning_rate_sigma=None, learning_rate_B=None,
              population_size=None, max_iter=2000,
-             fitness_shaping=True, mirrored_sampling=True, record_history=False):
+             fitness_shaping=True, mirrored_sampling=True, record_history=False,
+             rng=None):
     """
     Evolution strategies using the natural gradient of multinormal search distributions in natural coordinates.
     Does not consider covariances between parameters.
@@ -42,6 +43,11 @@ def optimize(func, mu, cov,
     if not is_positive_definite(cov):
         raise ValueError('covariance matrix needs to be positive semidefinite')
 
+    if rng is None:
+        rng = np.random.RandomState()
+    elif isinstance(rng, int):
+        rng = np.random.RandomState(seed=rng)
+
     generation = 0
     history_mu = []
     history_cov = []
@@ -64,7 +70,7 @@ def optimize(func, mu, cov,
     while True:
         assert(abs(np.linalg.det(B) - 1.) < 1e-12), 'determinant of root of covariance matrix unequal one'
 
-        s = np.random.normal(0, 1, size=(population_size, *np.shape(mu)))
+        s = rng.normal(0, 1, size=(population_size, *np.shape(mu)))
         z = mu + sigma * np.dot(s, B)
 
         if mirrored_sampling:

--- a/es/natural_es.py
+++ b/es/natural_es.py
@@ -6,7 +6,8 @@ from . import lib
 def optimize(func, mu, sigma,
              learning_rate_mu=None, learning_rate_sigma=None, population_size=None,
              sigma_lower_bound=1e-10, max_iter=2000,
-             fitness_shaping=True, mirrored_sampling=True, record_history=False):
+             fitness_shaping=True, mirrored_sampling=True, record_history=False,
+             rng=None):
     """
     Evolution strategies using the natural gradient of multinormal search distributions.
     Does not consider covariances between parameters.
@@ -25,13 +26,18 @@ def optimize(func, mu, sigma,
     if population_size is None:
         population_size = lib.default_population_size(mu.size)
 
+    if rng is None:
+        rng = np.random.RandomState()
+    elif isinstance(rng, int):
+        rng = np.random.RandomState(seed=rng)
+
     generation = 0
     history_mu = []
     history_sigma = []
     history_pop = []
 
     while True:
-        s = np.random.normal(0, 1, size=(population_size, *mu.shape))
+        s = rng.normal(0, 1, size=(population_size, *np.shape(mu)))
         z = mu + sigma * s
 
         if mirrored_sampling:

--- a/es/plain_es.py
+++ b/es/plain_es.py
@@ -5,8 +5,9 @@ from . import lib
 
 def optimize(func, mu, sigma,
              learning_rate_mu=None, learning_rate_sigma=None, population_size=None,
-             sigma_lower_bound=0.1, max_iter=2000,
-             fitness_shaping=True, mirrored_sampling=True, record_history=False):
+             sigma_lower_bound=1e-10, max_iter=2000,
+             fitness_shaping=True, mirrored_sampling=True, record_history=False,
+             rng=None):
     """
     Evolution strategies using the plain gradient of multinormal search distributions.
     Does not consider covariances between parameters.
@@ -20,13 +21,18 @@ def optimize(func, mu, sigma,
     if population_size is None:
         population_size = lib.default_population_size(mu.size)
 
+    if rng is None:
+        rng = np.random.RandomState()
+    elif isinstance(rng, int):
+        rng = np.random.RandomState(seed=rng)
+
     generation = 0
     history_mu = []
     history_sigma = []
     history_pop = []
 
     while True:
-        s = np.random.normal(0, 1, size=(population_size, *mu.shape))
+        s = rng.normal(0, 1, size=(population_size, *mu.shape))
         z = mu + sigma * s
 
         if mirrored_sampling:

--- a/es/separable_natural_es.py
+++ b/es/separable_natural_es.py
@@ -5,7 +5,8 @@ from . import lib
 def optimize(func, mu, sigma,
              learning_rate_mu=None, learning_rate_sigma=None, population_size=None,
              max_iter=2000,
-             fitness_shaping=True, mirrored_sampling=True, record_history=False):
+             fitness_shaping=True, mirrored_sampling=True, record_history=False,
+             rng=None):
     """
     Evolution strategies using the natural gradient of multinormal search distributions in natural coordinates.
     Does not consider covariances between parameters.
@@ -24,6 +25,11 @@ def optimize(func, mu, sigma,
     if population_size is None:
         population_size = lib.default_population_size(mu.size)
 
+    if rng is None:
+        rng = np.random.RandomState()
+    elif isinstance(rng, int):
+        rng = np.random.RandomState(seed=rng)
+
     generation = 0
     history_mu = []
     history_sigma = []
@@ -31,7 +37,7 @@ def optimize(func, mu, sigma,
     history_fitness = []
 
     while True:
-        s = np.random.normal(0, 1, size=(population_size, *np.shape(mu)))
+        s = rng.normal(0, 1, size=(population_size, *np.shape(mu)))
         z = mu + sigma * s
 
         if mirrored_sampling:


### PR DESCRIPTION
This PR introduces manual control of the random number generation in all algorithms. 

The user can now either

- set an RNG seed as an integer
- set a `numpy.random.RandomState` instance
- let the function create its own RandomState for random number generation.