### PR TITLE
Enable flexible random initialization of fitness function at each generation

### DIFF
--- a/es/separable_natural_es.py
+++ b/es/separable_natural_es.py
@@ -2,7 +2,9 @@ import multiprocessing as mp
 import numpy as np
 from . import lib
 
-def optimize(func, mu, sigma,
+def optimize(func,
+             mu, sigma,
+             func_wrapper=None,
              learning_rate_mu=None, learning_rate_sigma=None, population_size=None,
              max_iter=2000,
              fitness_shaping=True, mirrored_sampling=True, record_history=False,
@@ -45,11 +47,16 @@ def optimize(func, mu, sigma,
             z = np.vstack([z, mu - sigma * s])
             s = np.vstack([s, -s])
 
-        if parallel_threads is None:
-            fitness = np.fromiter((func(zi) for zi in z), np.float)
+        if func_wrapper is not None:
+            func_i = func_wrapper(func)
         else:
+            func_i = func
+
+        if parallel_threads is None:
+            fitness = np.fromiter((func_i(zi) for zi in z), np.float)
+        elif isinstance(parallel_threads, int):
             pool = mp.Pool(processes=parallel_threads)
-            fitness = np.fromiter(pool.map(func, z), np.float)
+            fitness = np.fromiter(pool.map(func_i, z), np.float)
             pool.close()
             pool.join()
 


### PR DESCRIPTION
This PR contains a solution to enable flexible initialization of the fitness function at each generation of the algorithm. This is necessary if one e.g. wants to use a different random sample of the task at each generation.

It is achieved by the option to pass a wrapper around the fitness function to the `optimize` function to enable flexible initialization of the fitness at each generation. 

This wrapper could for instance be created like this:
```
def func_wrapper(fitness, input_generator):
    input_spikes = next(input_generator)
    fitness_i = partial(fitness, input_spikes=input_spikes)
    return fitness_i

def generate_input_spikes(num_steps, params, seed=78293327):
    rng = np.random.RandomState(seed=seed)
    step = 0
    while step < num_steps:
        yield input_spike_sample(params, rng)
        step += 1

input_generator = generate_input_spikes(100, params)

func_wrapper_part = partial(func_wrapper, input_generator=input_generator)

result = optimize(fitness, func_wrapper=func_wrapper_part)
```

Here we created a generator for random samples of input spikes for some task for 100 generations. This generator is passed to the fitness function wrapper. In the `optimize` function, it is called at every generation where it uses the generator to create a new sample of input spikes and initializes the fitness function with this.